### PR TITLE
Update copyright string & filename of OFL

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2019 The Recursive Project Authors (info@arrowtype.com)
+Copyright 2020 The Noto Project Authors (github.com/googlei18n/noto-fonts)
 
 This Font Software is licensed under the SIL Open Font License, Version 1.1.
 This license is copied below, and is also available with a FAQ at:


### PR DESCRIPTION
Fixes https://github.com/LisaHuang2017/noto-sans-nushu/issues/6

Uses the same copyright string found in:
- https://github.com/googlefonts/noto-sans-hebrew/blob/master/LICENSE-fonts.txt
- https://github.com/googlefonts/noto-sans-bengali/blob/master/LICENSE-fonts.txt
- https://github.com/googlefonts/noto-sans-oriya/blob/master/LICENSE-fonts.txt

I've also made the filename just be `LICENSE`, so it's more similar to the other Noto repos, and more obvious to visitors who may not already know what an "OFL" is.